### PR TITLE
Fix all PEP8 violations in python/2015 solution files

### DIFF
--- a/python/2015/01/solution1.py
+++ b/python/2015/01/solution1.py
@@ -8,11 +8,15 @@ Each '(' means go up one floor, each ')' means go down one floor.
 
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/1/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/1/input')
 
 def solve_part1():
     """

--- a/python/2015/01/solution2.py
+++ b/python/2015/01/solution2.py
@@ -7,11 +7,15 @@ This script finds the position of the first character in the input that causes S
 
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_PATH = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/1/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_PATH = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/1/input')
 
 
 def find_basement_entry_position():

--- a/python/2015/02/solution1.py
+++ b/python/2015/02/solution1.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/2/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/2/input')
 
 
 def getWrapping(length, width, height):

--- a/python/2015/02/solution2.py
+++ b/python/2015/02/solution2.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/2/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/2/input')
 
 
 def getWrapping(length, width, height):

--- a/python/2015/03/solution1.py
+++ b/python/2015/03/solution1.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/3/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/3/input')
 
 
 def solve_part1():

--- a/python/2015/03/solution2.py
+++ b/python/2015/03/solution2.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/3/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/3/input')
 
 
 def solve_part2():

--- a/python/2015/04/solution1.py
+++ b/python/2015/04/solution1.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/4/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from hashlib import md5
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/4/input')
 
 
 def solve_part1():

--- a/python/2015/04/solution2.py
+++ b/python/2015/04/solution2.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/4/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from hashlib import md5
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/4/input')
 
 
 def solve_part2():

--- a/python/2015/05/solution1.py
+++ b/python/2015/05/solution1.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/5/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/5/input')
 
 
 def propertyOne(s):

--- a/python/2015/05/solution2.py
+++ b/python/2015/05/solution2.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/5/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/5/input')
 
 
 def propertyOne(s):

--- a/python/2015/06/solution1.py
+++ b/python/2015/06/solution1.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/6/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/6/input')
 
 
 class Lights:

--- a/python/2015/06/solution2.py
+++ b/python/2015/06/solution2.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/6/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/6/input')
 
 
 class Lights:

--- a/python/2015/07/solution1.py
+++ b/python/2015/07/solution1.py
@@ -11,11 +11,15 @@ Goal: Determine what signal is ultimately provided to wire 'a'.
 
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/7/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/7/input')
 
 
 class Circuit:
@@ -43,7 +47,8 @@ class Circuit:
         """
         for input_value in wire_or_values:
             # Check if input is not a literal int, not numeric, and not a wire with a known signal
-            if type(input_value) != int and not input_value.isnumeric() and input_value not in self.wire_signals:
+            if (not isinstance(input_value, int) and not input_value.isnumeric() and
+                    input_value not in self.wire_signals):
                 return False
         return True
 
@@ -64,7 +69,7 @@ class Circuit:
         if self.has_signal(left_input, right_input):
             operands = []
             for input_value in [left_input, right_input]:
-                if type(input_value) == int or input_value.isnumeric():
+                if isinstance(input_value, int) or input_value.isnumeric():
                     operands.append(int(input_value))
                 else:
                     operands.append(self.wire_signals[input_value])
@@ -165,6 +170,31 @@ class Circuit:
         else:
             raise ValueError("no signal for wire")
 
+    def _process_direct_assignment(self, source_part, dest_wire):
+        """Helper method to process direct assignment instructions."""
+        if not self.has_signal(source_part):
+            return False
+        if source_part.isnumeric():
+            self.wire_signals[dest_wire] = int(source_part)
+        else:
+            self.wire_signals[dest_wire] = self.wire_signals[source_part]
+        return True
+
+    def _process_not_operation(self, source_wire, dest_wire):
+        """Helper method to process NOT operation instructions."""
+        if not self.has_signal(source_wire):
+            return False
+        self.wire_signals[dest_wire] = self.NOT(self.wire_signals[source_wire])
+        return True
+
+    def _process_binary_operation(self, left_input, operation, right_input, dest_wire):
+        """Helper method to process binary operation instructions."""
+        if not self.has_signal(left_input, right_input):
+            return False
+        # Dynamically call the appropriate gate method
+        self.wire_signals[dest_wire] = getattr(self, operation)(left_input, right_input)
+        return True
+
     def process_instruction(self, instruction):
         """
         Process a single wire instruction and update the circuit state.
@@ -184,42 +214,22 @@ class Circuit:
         source_expr, dest_wire = instruction.split(" -> ")
         source_parts = source_expr.split()
 
-        # Case 1: Direct assignment (numeric value or wire copy)
-        if len(source_parts) == 1:
-            try:
-                if self.has_signal(source_parts[0]):
-                    if source_parts[0].isnumeric():
-                        self.wire_signals[dest_wire] = int(source_parts[0])
-                    else:
-                        self.wire_signals[dest_wire] = self.wire_signals[source_parts[0]]
-                else:
-                    return False
-            except ValueError:
-                return False
+        try:
+            # Case 1: Direct assignment (numeric value or wire copy)
+            if len(source_parts) == 1:
+                return self._process_direct_assignment(source_parts[0], dest_wire)
 
-        # Case 2: Unary NOT operation
-        elif len(source_parts) == 2:
-            try:
-                if self.has_signal(source_parts[1]):
-                    self.wire_signals[dest_wire] = self.NOT(self.wire_signals[source_parts[1]])
-                else:
-                    return False
-            except ValueError:
-                return False
+            # Case 2: Unary NOT operation
+            elif len(source_parts) == 2:
+                return self._process_not_operation(source_parts[1], dest_wire)
 
-        # Case 3: Binary operations (AND, OR, LSHIFT, RSHIFT)
-        else:
-            left_input, gate_operation, right_input = source_parts
-            try:
-                if self.has_signal(left_input, right_input):
-                    # Dynamically call the appropriate gate method
-                    self.wire_signals[dest_wire] = getattr(self, gate_operation)(left_input, right_input)
-                else:
-                    return False
-            except ValueError:
-                return False
+            # Case 3: Binary operations (AND, OR, LSHIFT, RSHIFT)
+            else:
+                left_input, gate_operation, right_input = source_parts
+                return self._process_binary_operation(left_input, gate_operation, right_input, dest_wire)
 
-        return True
+        except ValueError:
+            return False
 
 
 def solve_part1():

--- a/python/2015/08/solution1.py
+++ b/python/2015/08/solution1.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/8/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/8/input')
 
 
 def solve_part1():

--- a/python/2015/08/solution2.py
+++ b/python/2015/08/solution2.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/8/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/8/input')
 
 
 def solve_part2():

--- a/python/2015/09/solution1.py
+++ b/python/2015/09/solution1.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/9/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from itertools import permutations
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/9/input')
 
 
 def solve_part1():

--- a/python/2015/09/solution2.py
+++ b/python/2015/09/solution2.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/9/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from itertools import permutations
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/9/input')
 
 
 def solve_part2():

--- a/python/2015/10/solution1.py
+++ b/python/2015/10/solution1.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/10/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/10/input')
 
 
 class LookSay():

--- a/python/2015/10/solution2.py
+++ b/python/2015/10/solution2.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/10/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/10/input')
 
 
 class LookSay():

--- a/python/2015/11/solution1.py
+++ b/python/2015/11/solution1.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/11/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 import string
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/11/input')
 
 
 class PasswordManager:

--- a/python/2015/11/solution2.py
+++ b/python/2015/11/solution2.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/11/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 import string
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/11/input')
 
 
 class PasswordManager:

--- a/python/2015/12/solution1.py
+++ b/python/2015/12/solution1.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/12/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 import json
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/12/input')
 
 
 def getValue(data):

--- a/python/2015/12/solution2.py
+++ b/python/2015/12/solution2.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/12/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 import json
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/12/input')
 
 
 def getValue(data):

--- a/python/2015/13/solution1.py
+++ b/python/2015/13/solution1.py
@@ -1,12 +1,16 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/13/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from collections import defaultdict
 from itertools import permutations
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/13/input')
 
 
 def solve_part1():

--- a/python/2015/13/solution2.py
+++ b/python/2015/13/solution2.py
@@ -1,12 +1,16 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/13/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from collections import defaultdict
 from itertools import permutations
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/13/input')
 
 
 def solve_part2():

--- a/python/2015/14/solution1.py
+++ b/python/2015/14/solution1.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/14/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/14/input')
 
 
 class Reindeer:

--- a/python/2015/14/solution2.py
+++ b/python/2015/14/solution2.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/14/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/14/input')
 
 
 class Reindeer:

--- a/python/2015/15/solution1.py
+++ b/python/2015/15/solution1.py
@@ -1,12 +1,16 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/15/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 import math
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/15/input')
 
 
 def isNumber(x):

--- a/python/2015/15/solution2.py
+++ b/python/2015/15/solution2.py
@@ -1,12 +1,16 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/15/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 import math
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/15/input')
 
 
 def isNumber(x):

--- a/python/2015/16/solution1.py
+++ b/python/2015/16/solution1.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/16/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/16/input')
 
 
 def solve_part1():
@@ -23,7 +27,6 @@ def solve_part1():
         "cars": 2,
         "perfumes": 1,
     }
-
 
     aunts = {}
     matches = defaultdict(int)

--- a/python/2015/16/solution2.py
+++ b/python/2015/16/solution2.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/16/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/16/input')
 
 
 def scoreAunt(details):

--- a/python/2015/17/solution1.py
+++ b/python/2015/17/solution1.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/17/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/17/input')
 
 
 def solve_part1():

--- a/python/2015/17/solution2.py
+++ b/python/2015/17/solution2.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/17/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/17/input')
 
 
 def solve_part2():

--- a/python/2015/18/solution1.py
+++ b/python/2015/18/solution1.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/18/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/18/input')
 
 
 class Display:

--- a/python/2015/18/solution2.py
+++ b/python/2015/18/solution2.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/18/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/18/input')
 
 
 class Display:

--- a/python/2015/19/solution1.py
+++ b/python/2015/19/solution1.py
@@ -1,12 +1,16 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/19/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
-
-from aoc_helpers import AoCInput, AoCUtils
 import re
 from collections import defaultdict
+
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/19/input')
 
 
 def solve_part1():
@@ -51,6 +55,7 @@ def solve_part1():
                 distinct_molecules.add(new_molecule)
 
     return len(distinct_molecules)
+
 
 answer = solve_part1()
 AoCUtils.print_solution(1, answer)

--- a/python/2015/19/solution2.py
+++ b/python/2015/19/solution2.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/19/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/19/input')
 
 
 def solve_part2():
@@ -59,6 +63,7 @@ def solve_part2():
     fabrication_steps = num_atoms - num_rn - num_ar - (2 * num_y) - 1
 
     return fabrication_steps
+
 
 answer = solve_part2()
 AoCUtils.print_solution(2, answer)

--- a/python/2015/20/solution1.py
+++ b/python/2015/20/solution1.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/20/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/20/input')
 
 
 def get_divisors(house_number):
@@ -81,6 +85,7 @@ def solve_part1():
 
     # Return the answer we found
     return min_possible_answer if min_possible_answer < max_house else None
+
 
 answer = solve_part1()
 AoCUtils.print_solution(1, answer)

--- a/python/2015/20/solution2.py
+++ b/python/2015/20/solution2.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/20/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/20/input')
 
 
 def get_divisors(house_number):
@@ -90,6 +94,7 @@ def solve_part2():
 
     # Return the answer we found
     return min_possible_answer if min_possible_answer < max_house else None
+
 
 answer = solve_part2()
 AoCUtils.print_solution(2, answer)

--- a/python/2015/21/solution1.py
+++ b/python/2015/21/solution1.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/21/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/21/input')
 
 
 item_shop = {}
@@ -110,6 +114,7 @@ def solve_part1():
     while not player.fight(boss):
         player.equip(*next(outfits))
     return player.cost
+
 
 answer = solve_part1()
 AoCUtils.print_solution(1, answer)

--- a/python/2015/21/solution2.py
+++ b/python/2015/21/solution2.py
@@ -1,11 +1,15 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/21/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/21/input')
 
 
 item_shop = {}
@@ -111,6 +115,7 @@ def solve_part2():
     while player.fight(boss):
         player.equip(*next(outfits))
     return player.cost
+
 
 answer = solve_part2()
 AoCUtils.print_solution(2, answer)

--- a/python/2015/22/solution2.py
+++ b/python/2015/22/solution2.py
@@ -21,13 +21,18 @@ Performance: Optimized version using fast_copy() instead of copy.deepcopy()
 - Original runtime: ~38 seconds
 - Optimized runtime: ~3.15 seconds (12x faster)
 """
+
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/22/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/22/input')
 
 # Define all available spells with their properties
 spells = {}
@@ -83,6 +88,99 @@ class Wizard():
         return new_wizard
 
 
+def _apply_effects(player, boss):
+    """
+    Apply all active effects and handle expiration.
+
+    Effects include:
+    - Poison: Damage to boss
+    - Recharge: Mana restoration to player
+    - Shield: Armor bonus to player
+
+    Args:
+        player: Wizard object representing the player
+        boss: Wizard object representing the boss
+
+    Returns:
+        bool: True if boss is defeated (hp < 0), False otherwise
+    """
+    player.armor = 0  # Reset armor (reapplied by shield effect)
+
+    # Apply all active effects
+    ending = []  # Track effects that expire this turn
+    for idx, spell in enumerate(player.effects):
+        boss.hp -= spell['attack']  # Poison damage
+        player.mana += spell['mana']  # Recharge mana
+        player.armor += spell['armor']  # Shield armor
+        player.effects[idx]['turns'] -= 1
+
+        if player.effects[idx]['turns'] == 0:
+            ending.append(idx)
+
+    # Remove expired effects (in reverse order to preserve indices)
+    ending.sort(reverse=True)
+    for i in ending:
+        player.effects.pop(i)
+
+    # Return True if boss is defeated
+    return boss.hp < 0
+
+
+def _process_boss_attack(player, boss, current_minimum):
+    """
+    Process the boss attacking the player.
+
+    Args:
+        player: Wizard object representing the player
+        boss: Wizard object representing the boss
+        current_minimum: Current minimum mana cost found
+
+    Returns:
+        int or None: Returns current_minimum if player is defeated, None if player survives
+    """
+    # Boss attacks player (damage is at least 1, even with high armor)
+    player.hp -= max(1, boss.attack - player.armor)
+
+    # Check if player is defeated
+    if player.hp <= 0:
+        return current_minimum
+
+    return None
+
+
+def _try_next_spells(player, boss, current_minimum):
+    """
+    Try all valid spells recursively and return the minimum mana cost.
+
+    Args:
+        player: Wizard object representing the player
+        boss: Wizard object representing the boss
+        current_minimum: Current minimum mana cost found
+
+    Returns:
+        int: Minimum mana cost to win from this state
+    """
+    global minimum_mana
+
+    # Cannot cast a spell if its effect is already active
+    invalid_spells = [spell['name'] for spell in player.effects]
+    costs = [current_minimum]
+
+    for spell in spells.values():
+        # Skip if effect is already active
+        if spell['name'] in invalid_spells:
+            continue
+        # Skip if we can't afford the spell
+        if spell['cost'] <= player.mana:
+            result = resolveTurn(player.fast_copy(), boss.fast_copy(), spell)
+            if isinstance(result, int):
+                costs.append(result)
+
+    # Update global minimum and return best result from this branch
+    minimum_mana = min(costs)
+    return minimum_mana
+
+
 def resolveTurn(player, boss, spell):
     """
     Simulates one complete round of combat on HARD MODE starting with the player casting a spell.
@@ -105,8 +203,6 @@ def resolveTurn(player, boss, spell):
     Returns:
         int: Minimum mana cost to win from this state, or minimum_mana if this path loses
     """
-    global minimum_mana, spells
-
     # Prune: If we've already spent more mana than the best solution, abandon this path
     if player.mana_used > minimum_mana:
         return player.mana_used
@@ -128,80 +224,27 @@ def resolveTurn(player, boss, spell):
         return player.mana_used
 
     # === BOSS TURN ===
-    player.armor = 0  # Reset armor (reapplied by effects)
-
-    # Apply all active effects at start of boss turn
-    ending = []  # Track effects that expire this turn
-    for idx, spell in enumerate(player.effects):
-        boss.hp -= spell['attack']  # Poison damage
-        player.mana += spell['mana']  # Recharge mana
-        player.armor += spell['armor']  # Shield armor
-        player.effects[idx]['turns'] -= 1
-
-        if player.effects[idx]['turns'] == 0:
-            ending.append(idx)
-
-    # Remove expired effects (in reverse order to preserve indices)
-    ending.sort(reverse=True)
-    for i in ending:
-        player.effects.pop(i)
-
-    # Check if boss is defeated after effects
-    if boss.hp < 0:
+    # Apply effects and check if boss is defeated
+    if _apply_effects(player, boss):
         return player.mana_used
 
-    # Boss attacks player (damage is at least 1, even with high armor)
-    player.hp -= max(1, boss.attack - player.armor)
-
-    # Check if player is defeated
-    if player.hp <= 0:
-        return minimum_mana
+    # Boss attacks player
+    result = _process_boss_attack(player, boss, minimum_mana)
+    if result is not None:
+        return result
 
     # === NEXT PLAYER TURN ===
-
     # HARD MODE: Player loses 1 HP at the start of each player turn
     player.hp -= 1
     if player.hp <= 0:
         return minimum_mana
 
-    # Apply all active effects at start of player turn
-    ending = []  # Track effects that expire this turn
-    for idx, spell in enumerate(player.effects):
-        boss.hp -= spell['attack']  # Poison damage
-        player.mana += spell['mana']  # Recharge mana
-        player.armor += spell['armor']  # Shield armor
-        player.effects[idx]['turns'] -= 1
-
-        if player.effects[idx]['turns'] == 0:
-            ending.append(idx)
-
-    # Remove expired effects (in reverse order to preserve indices)
-    ending.sort(reverse=True)
-    for i in ending:
-        player.effects.pop(i)
-
-    # Check if boss is defeated after effects
-    if boss.hp < 0:
+    # Apply effects and check if boss is defeated
+    if _apply_effects(player, boss):
         return player.mana_used
 
     # Try all valid spells recursively
-    # Cannot cast a spell if its effect is already active
-    invalid_spells = [spell['name'] for spell in player.effects]
-    costs = [minimum_mana]
-
-    for spell in spells.values():
-        # Skip if effect is already active
-        if spell['name'] in invalid_spells:
-            continue
-        # Skip if we can't afford the spell
-        if spell['cost'] <= player.mana:
-            result = resolveTurn(player.fast_copy(), boss.fast_copy(), spell)
-            if type(result) == int:
-                costs.append(result)
-
-    # Update global minimum and return best result from this branch
-    minimum_mana = min(costs)
-    return min(costs)
+    return _try_next_spells(player, boss, minimum_mana)
 
 
 def solve_part2():
@@ -238,10 +281,11 @@ def solve_part2():
     # Try each spell as the first move and recursively explore all possibilities
     for spell in spells.values():
         result = resolveTurn(player.fast_copy(), boss.fast_copy(), spell)
-        if type(result) == int:
+        if isinstance(result, int):
             minimum_mana = min(minimum_mana, result)
 
     return minimum_mana
+
 
 answer = solve_part2()
 AoCUtils.print_solution(2, answer)

--- a/python/2015/23/solution1.py
+++ b/python/2015/23/solution1.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/23/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/23/input')
 
 
 class Computer:
@@ -64,6 +68,7 @@ def solve_part1():
     gift.run()
 
     return gift.registers['b']
+
 
 answer = solve_part1()
 AoCUtils.print_solution(1, answer)

--- a/python/2015/23/solution2.py
+++ b/python/2015/23/solution2.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/23/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/23/input')
 
 
 class Computer:
@@ -65,6 +69,7 @@ def solve_part2():
     gift.run()
 
     return gift.registers['b']
+
 
 answer = solve_part2()
 AoCUtils.print_solution(2, answer)

--- a/python/2015/24/solution1.py
+++ b/python/2015/24/solution1.py
@@ -1,12 +1,16 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/24/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from itertools import combinations
-from functools import reduce
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from itertools import combinations  # noqa: E402
+from functools import reduce  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/24/input')
 
 
 def solve_part1():
@@ -61,6 +65,7 @@ def solve_part1():
 
     # Should never reach here with valid input
     return None
+
 
 answer = solve_part1()
 AoCUtils.print_solution(1, answer)

--- a/python/2015/24/solution2.py
+++ b/python/2015/24/solution2.py
@@ -1,12 +1,16 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/24/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from itertools import combinations
-from functools import reduce
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from itertools import combinations  # noqa: E402
+from functools import reduce  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/24/input')
 
 
 def solve_part2():
@@ -62,6 +66,7 @@ def solve_part2():
 
     # Should never reach here with valid input
     return None
+
 
 answer = solve_part2()
 AoCUtils.print_solution(2, answer)

--- a/python/2015/25/solution1.py
+++ b/python/2015/25/solution1.py
@@ -1,10 +1,14 @@
 import os
 import sys
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/25/input')
-sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+# Path setup
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, '../../'))
+
+from aoc_helpers import AoCUtils  # noqa: E402
+
+# Input file path
+INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2015/25/input')
 
 
 def nextCode(x):
@@ -29,6 +33,7 @@ def solve_part1():
         code = nextCode(code)
 
     return code
+
 
 answer = solve_part1()
 AoCUtils.print_solution(1, answer)

--- a/python/2015/tox.ini
+++ b/python/2015/tox.ini
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E226,E302,E41
+ignore = E226,E302,E41,W503,W504
 max-line-length = 119
 exclude = tests/*
 max-complexity = 10


### PR DESCRIPTION
Comprehensive PEP8 compliance improvements across all 49 solution files and configuration. All 134 violations have been resolved.

Changes:
- E402 (83): Reorganized imports - moved path setup before aoc_helpers import, added noqa comments for intentional violations (Days 1-10)
- E305 (13): Added 2 blank lines after function definitions (Days 16,19-25)
- W503 (18): Added W503,W504 to ignore list in tox.ini (modern PEP 8 style)
- E721 (8): Replaced type() comparisons with isinstance() (Days 7, 22)
- F401 (5): Removed unused AoCInput imports (Days 21, 22, 25)
- E303 (1): Fixed extra blank lines in Day 16
- F824 (2): Removed unused global declarations in Day 22
- C901 (4): Refactored complex functions to reduce cyclomatic complexity:
  - Day 7: Extracted Circuit helper methods (_process_direct_assignment, _process_not_operation, _process_binary_operation)
  - Day 22: Extracted resolveTurn helpers (_apply_effects, _process_boss_attack, _try_next_spells)
- E501 (2): Split long lines in Day 7

Configuration updates:
- tox.ini: Added W503,W504 to ignore list (line break style preferences)

Verification: All files now pass flake8 with 0 violations