### PR TITLE
Fix all PEP8 violations in python/2017 solution files

### DIFF
--- a/python/2017/01/solution1.py
+++ b/python/2017/01/solution1.py
@@ -17,7 +17,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/1/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def calculate_captcha_sum(digits):

--- a/python/2017/01/solution2.py
+++ b/python/2017/01/solution2.py
@@ -19,7 +19,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/1/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def calculate_captcha_sum_halfway(digits):

--- a/python/2017/02/solution1.py
+++ b/python/2017/02/solution1.py
@@ -17,7 +17,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/2/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def calculate_row_difference(row_values):

--- a/python/2017/02/solution2.py
+++ b/python/2017/02/solution2.py
@@ -17,7 +17,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/2/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def find_evenly_divisible_quotient(row_values):

--- a/python/2017/03/solution1.py
+++ b/python/2017/03/solution1.py
@@ -18,7 +18,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/3/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCUtils  # noqa: E402
 
 
 def build_spiral_to_target(target_square):
@@ -74,6 +74,7 @@ def main():
     # Calculate Manhattan distance (subtract 1 for moves, not locations)
     manhattan_distance = abs(x) + abs(y) - 1
     AoCUtils.print_solution(1, manhattan_distance)
+
 
 if __name__ == "__main__":
     main()

--- a/python/2017/03/solution2.py
+++ b/python/2017/03/solution2.py
@@ -19,7 +19,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/3/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCUtils  # noqa: E402
 
 
 def get_adjacent_positions(location):

--- a/python/2017/04/solution1.py
+++ b/python/2017/04/solution1.py
@@ -16,7 +16,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/4/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def is_valid_passphrase(passphrase):

--- a/python/2017/04/solution2.py
+++ b/python/2017/04/solution2.py
@@ -19,7 +19,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/4/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def is_valid_passphrase_no_anagrams(passphrase):

--- a/python/2017/05/solution1.py
+++ b/python/2017/05/solution1.py
@@ -21,7 +21,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/5/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def count_steps_to_exit(jump_offsets):

--- a/python/2017/05/solution2.py
+++ b/python/2017/05/solution2.py
@@ -16,7 +16,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/5/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def count_steps_to_exit_with_decrease(jump_offsets):

--- a/python/2017/06/solution1.py
+++ b/python/2017/06/solution1.py
@@ -17,7 +17,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/6/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def reallocate_memory(memory_banks):
@@ -64,7 +64,6 @@ def main():
         cycles += 1
 
     AoCUtils.print_solution(1, cycles)
-    
 
 
 if __name__ == "__main__":

--- a/python/2017/06/solution2.py
+++ b/python/2017/06/solution2.py
@@ -17,8 +17,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/6/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
 
 
 def reallocate_memory(memory_banks):

--- a/python/2017/07/solution1.py
+++ b/python/2017/07/solution1.py
@@ -25,7 +25,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/7/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 class ProgramNode():

--- a/python/2017/07/solution2.py
+++ b/python/2017/07/solution2.py
@@ -20,8 +20,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/7/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
 
 
 class ProgramNode():

--- a/python/2017/08/solution1.py
+++ b/python/2017/08/solution1.py
@@ -22,8 +22,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/8/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
 
 
 class RegisterComputer():

--- a/python/2017/08/solution2.py
+++ b/python/2017/08/solution2.py
@@ -15,8 +15,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/8/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
 
 
 class RegisterComputer():

--- a/python/2017/09/solution1.py
+++ b/python/2017/09/solution1.py
@@ -29,7 +29,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/9/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def remove_garbage(stream):

--- a/python/2017/09/solution2.py
+++ b/python/2017/09/solution2.py
@@ -21,7 +21,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/9/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def count_garbage_characters(stream):

--- a/python/2017/10/solution1.py
+++ b/python/2017/10/solution1.py
@@ -25,8 +25,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/10/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import deque
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from collections import deque  # noqa: E402
 
 
 def process_knot_hash(ring, lengths):

--- a/python/2017/10/solution2.py
+++ b/python/2017/10/solution2.py
@@ -11,8 +11,8 @@ Implement the full Knot Hash algorithm with these modifications from Part 1:
 Examples:
     Empty string "" = a2582a3a0e66e6e86e3812dcb672a272
     "AoC 2017" = 33efeb34ea91902bb2f59c9920caa6cd
-    "1,2,3" = 3efbe78a8d82f29979031a4aa0b16a9d
-    "1,2,4" = 63960835bcdc130f0b66d7ff4f6a5a8e
+    "1, 2, 3" = 3efbe78a8d82f29979031a4aa0b16a9d
+    "1, 2, 4" = 63960835bcdc130f0b66d7ff4f6a5a8e
 """
 
 import os
@@ -21,8 +21,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/10/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import deque
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from collections import deque  # noqa: E402
 
 
 def compute_knot_hash(input_string):

--- a/python/2017/11/solution1.py
+++ b/python/2017/11/solution1.py
@@ -11,10 +11,10 @@ Distance calculation: The hex distance is the maximum absolute value of the thre
 cube coordinates divided by 2 (or equivalently, sum of absolute values / 2).
 
 Examples:
-    ne,ne,ne = 3 steps away
-    ne,ne,sw,sw = 0 steps away (back at start)
-    ne,ne,s,s = 2 steps away (equivalent to se,se)
-    se,sw,se,sw,sw = 3 steps away (equivalent to s,s,sw)
+    ne, ne, ne = 3 steps away
+    ne, ne, sw, sw = 0 steps away (back at start)
+    ne, ne, s, s = 2 steps away (equivalent to se, se)
+    se, sw, se, sw, sw = 3 steps away (equivalent to s, s, sw)
 """
 
 import os
@@ -23,7 +23,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/11/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 class HexGrid():

--- a/python/2017/11/solution2.py
+++ b/python/2017/11/solution2.py
@@ -15,7 +15,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/11/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 class HexGrid():

--- a/python/2017/12/solution1.py
+++ b/python/2017/12/solution1.py
@@ -29,8 +29,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/12/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-import networkx as nx
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+import networkx as nx  # noqa: E402
 
 
 def build_communication_network(lines):

--- a/python/2017/12/solution2.py
+++ b/python/2017/12/solution2.py
@@ -15,8 +15,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/12/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-import networkx as nx
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+import networkx as nx  # noqa: E402
 
 
 def build_communication_network(lines):

--- a/python/2017/13/solution1.py
+++ b/python/2017/13/solution1.py
@@ -28,7 +28,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/13/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def parse_firewall(lines):

--- a/python/2017/13/solution2.py
+++ b/python/2017/13/solution2.py
@@ -18,7 +18,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/13/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def parse_firewall(lines):

--- a/python/2017/14/solution1.py
+++ b/python/2017/14/solution1.py
@@ -20,8 +20,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/14/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import deque
+from aoc_helpers import AoCUtils  # noqa: E402
+from collections import deque  # noqa: E402
 
 
 def compute_knot_hash(input_string):

--- a/python/2017/14/solution2.py
+++ b/python/2017/14/solution2.py
@@ -15,9 +15,9 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/14/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import deque
-import networkx as nx
+from aoc_helpers import AoCUtils  # noqa: E402
+from collections import deque  # noqa: E402
+import networkx as nx  # noqa: E402
 
 
 def compute_knot_hash(input_string):

--- a/python/2017/15/solution1.py
+++ b/python/2017/15/solution1.py
@@ -23,7 +23,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/15/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCUtils  # noqa: E402
 
 
 def create_generator(factor, initial_value):

--- a/python/2017/15/solution2.py
+++ b/python/2017/15/solution2.py
@@ -24,7 +24,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/15/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCUtils  # noqa: E402
 
 
 def create_generator(factor, initial_value):

--- a/python/2017/16/solution1.py
+++ b/python/2017/16/solution1.py
@@ -21,7 +21,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/16/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 class DanceSimulator():

--- a/python/2017/16/solution2.py
+++ b/python/2017/16/solution2.py
@@ -12,7 +12,7 @@ Strategy:
 1. Perform the dance repeatedly
 2. Track when we return to the starting configuration
 3. Calculate the cycle length
-4. Use modulo arithmetic to find the state at iteration 1,000,000,000
+4. Use modulo arithmetic to find the state at iteration 1, 000, 000, 000
 """
 
 import os
@@ -21,7 +21,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/16/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 class DanceSimulator():

--- a/python/2017/17/solution1.py
+++ b/python/2017/17/solution1.py
@@ -21,7 +21,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/17/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCUtils  # noqa: E402
 
 
 def simulate_spinlock(step_size, num_insertions):

--- a/python/2017/17/solution2.py
+++ b/python/2017/17/solution2.py
@@ -19,7 +19,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/17/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCUtils  # noqa: E402
 
 
 def find_value_after_zero(step_size, num_insertions):

--- a/python/2017/18/solution1.py
+++ b/python/2017/18/solution1.py
@@ -20,9 +20,9 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/18/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
-from string import ascii_lowercase as letters
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
+from string import ascii_lowercase as letters  # noqa: E402
 
 
 class DuetProgram():

--- a/python/2017/18/solution2.py
+++ b/python/2017/18/solution2.py
@@ -16,9 +16,9 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/18/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
-from string import ascii_lowercase as letters
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
+from string import ascii_lowercase as letters  # noqa: E402
 
 
 class DuetProgram():
@@ -47,7 +47,7 @@ class DuetProgram():
             if instruction[0] != 'jgz':
                 self.pointer += 1
             # If blocked on receive, return control to allow partner to run
-            if self.waiting == True:
+            if self.waiting:
                 return
         # Program terminated (pointer out of range)
         self.waiting = True

--- a/python/2017/19/solution1.py
+++ b/python/2017/19/solution1.py
@@ -17,7 +17,56 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/19/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+
+
+def build_routing_diagram(lines):
+    """Build a dictionary of all non-space positions in the routing diagram.
+
+    Args:
+        lines: List of strings representing the routing diagram
+
+    Returns:
+        Dictionary mapping (x, y) coordinates to characters
+    """
+    routing_diagram = {}
+    for y, line in enumerate(lines):
+        for x, point in enumerate([*line]):
+            if point != ' ':
+                routing_diagram[(x, y)] = point
+    return routing_diagram
+
+
+def find_new_direction(position, heading, directions, routing_diagram):
+    """Find the new direction to turn at a corner.
+
+    Args:
+        position: Current (x, y) position
+        heading: Current heading (0=down, 1=left, 2=up, 3=right)
+        directions: List of direction vectors
+        routing_diagram: Dictionary of diagram positions
+
+    Returns:
+        New heading direction
+
+    Raises:
+        RuntimeError: If no valid turn is found
+    """
+    reverse = (heading + 2) % 4  # Opposite direction (where we came from)
+
+    for new_heading in range(4):
+        if new_heading == reverse:
+            continue  # Don't go backwards
+
+        new_x = position[0] + directions[new_heading][0]
+        new_y = position[1] + directions[new_heading][1]
+        next_char = routing_diagram.get((new_x, new_y), '')
+
+        # Valid path if there's any non-space character
+        if next_char and next_char != ' ':
+            return new_heading
+
+    raise RuntimeError("No valid turn found at corner!")
 
 
 def main():
@@ -25,12 +74,8 @@ def main():
     # Read lines preserving leading spaces (they're significant for positioning)
     lines = AoCInput.read_lines(INPUT_FILE, preserve_leading_space=True)
 
-    # Build a dictionary of all non-space positions in the routing diagram
-    routing_diagram = {}
-    for y, line in enumerate(lines):
-        for x, point in enumerate([*line]):
-            if point != ' ':
-                routing_diagram[(x, y)] = point
+    # Build routing diagram
+    routing_diagram = build_routing_diagram(lines)
 
     # Direction vectors: down, left, up, right (indexed 0-3)
     directions = [(0, 1), (-1, 0), (0, -1), (1, 0)]
@@ -46,30 +91,11 @@ def main():
         current_char = routing_diagram[position]
 
         if current_char in ['|', '-']:
-            # Continue straight on path segments (paths can cross each other)
+            # Continue straight on path segments
             pass
         elif current_char == '+':
-            # Corner: check all directions except where we came from
-            reverse = (heading + 2) % 4  # Opposite direction (where we came from)
-
-            # Check all three possible directions (left, right, and straight)
-            found_turn = False
-            for new_heading in range(4):
-                if new_heading == reverse:
-                    continue  # Don't go backwards
-
-                new_x = position[0] + directions[new_heading][0]
-                new_y = position[1] + directions[new_heading][1]
-                next_char = routing_diagram.get((new_x, new_y), '')
-
-                # Valid path if there's any non-space character (except we came from)
-                if next_char and next_char != ' ':
-                    heading = new_heading
-                    found_turn = True
-                    break
-
-            if not found_turn:
-                raise RuntimeError("No valid turn found at corner!")
+            # Corner: find new direction
+            heading = find_new_direction(position, heading, directions, routing_diagram)
         else:
             # Letter marker - collect it
             collected_letters = collected_letters + routing_diagram[position]

--- a/python/2017/19/solution2.py
+++ b/python/2017/19/solution2.py
@@ -13,7 +13,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/19/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def main():
@@ -50,7 +50,7 @@ def main():
             new_path_char = expected_turn_char[heading]
             # Next position is either left or right of current heading
             left = (heading - 1) % 4
-            left_x, left_y  = position[0] + directions[left][0], position[1] + directions[left][1]
+            left_x, left_y = position[0] + directions[left][0], position[1] + directions[left][1]
             right = (heading + 1) % 4
 
             # Turn toward whichever side has the expected path character

--- a/python/2017/20/solution1.py
+++ b/python/2017/20/solution1.py
@@ -6,7 +6,7 @@ Each tick:
 1. Velocity increases by acceleration
 2. Position increases by velocity
 
-The challenge is to determine which particle will stay closest to position <0,0,0>
+The challenge is to determine which particle will stay closest to position <0, 0, 0>
 in the long term, as measured by Manhattan distance (sum of absolute coordinates).
 
 The answer is the ID of the particle that remains closest over infinite time.
@@ -17,16 +17,16 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/20/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 class Particle():
     """Represents a particle with position, velocity, and acceleration in 3D space."""
     def __init__(self):
         self.id = 0
-        self.acceleration = (0,0,0)
-        self.velocity = (0,0,0)
-        self.position = (0,0,0)
+        self.acceleration = (0, 0, 0)
+        self.velocity = (0, 0, 0)
+        self.position = (0, 0, 0)
         self.delta = 0  # Change in distance from origin after last move
 
     def move(self):
@@ -58,7 +58,7 @@ def main():
 
     # Parse particle data
     for idx, line in enumerate(lines):
-        p,v,a = [x.split('<')[1][:-1] for x in line.strip().split(', ')]
+        p, v, a = [x.split('<')[1][:-1] for x in line.strip().split(', ')]
         particle = Particle()
         particle.acceleration = tuple([int(x) for x in a.split(',')])
         particle.velocity = tuple([int(x) for x in v.split(',')])

--- a/python/2017/20/solution2.py
+++ b/python/2017/20/solution2.py
@@ -14,16 +14,16 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/20/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
 
 
 class Particle():
     """Represents a particle with position, velocity, and acceleration in 3D space."""
     def __init__(self):
-        self.acceleration = (0,0,0)
-        self.velocity = (0,0,0)
-        self.position = (0,0,0)
+        self.acceleration = (0, 0, 0)
+        self.velocity = (0, 0, 0)
+        self.position = (0, 0, 0)
 
     def move_old(self):
         """Legacy move method (unused)."""
@@ -36,7 +36,7 @@ class Particle():
 
     def move(self):
         """Update velocity by acceleration, then update position by velocity."""
-        a,v,p = list(self.acceleration), list(self.velocity), list(self.position)
+        a, v, p = list(self.acceleration), list(self.velocity), list(self.position)
         for i in range(3):
             v[i] += a[i]
             p[i] += v[i]
@@ -52,7 +52,7 @@ def main():
 
     # Parse particle data
     for idx, line in enumerate(lines):
-        p,v,a = [x.split('<')[1][:-1] for x in line.strip().split(', ')]
+        p, v, a = [x.split('<')[1][:-1] for x in line.strip().split(', ')]
         particle = Particle()
         particle.acceleration = tuple([int(x) for x in a.split(',')])
         particle.velocity = tuple([int(x) for x in v.split(',')])

--- a/python/2017/21/solution1.py
+++ b/python/2017/21/solution1.py
@@ -19,8 +19,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/21/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from math import isqrt
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from math import isqrt  # noqa: E402
 
 
 def rotate_patterns(pattern):

--- a/python/2017/21/solution2.py
+++ b/python/2017/21/solution2.py
@@ -13,8 +13,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/21/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from math import isqrt
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from math import isqrt  # noqa: E402
 
 
 def rotate_patterns(pattern):

--- a/python/2017/22/solution1.py
+++ b/python/2017/22/solution1.py
@@ -7,7 +7,7 @@ The carrier follows these rules in each burst:
 2. Toggle the node's state (clean->infected, infected->clean)
 3. Move forward one node in the current direction
 
-Starting at the grid's center facing up, after 10,000 bursts of activity,
+Starting at the grid's center facing up, after 10, 000 bursts of activity,
 count how many bursts cause a node to become infected.
 """
 import os
@@ -16,8 +16,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/22/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
 
 
 class VirusCarrier():
@@ -65,7 +65,7 @@ class VirusCarrier():
 
 
 def main():
-    """Simulate virus spread for 10,000 bursts and count infections."""
+    """Simulate virus spread for 10, 000 bursts and count infections."""
     lines = AoCInput.read_lines(INPUT_FILE)
 
     # Parse the initial grid of infected nodes

--- a/python/2017/22/solution2.py
+++ b/python/2017/22/solution2.py
@@ -13,7 +13,7 @@ The carrier's behavior changes each burst:
 3. Infected node: turn right, become flagged
 4. Flagged node: reverse direction, become clean
 
-After 10,000,000 bursts, count how many times a node becomes infected.
+After 10, 000, 000 bursts, count how many times a node becomes infected.
 """
 import os
 import sys
@@ -21,7 +21,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/22/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 class EvolvedVirusCarrier():
@@ -88,7 +88,7 @@ class EvolvedVirusCarrier():
 
 
 def main():
-    """Simulate evolved virus spread for 10,000,000 bursts and count infections."""
+    """Simulate evolved virus spread for 10, 000, 000 bursts and count infections."""
     lines = AoCInput.read_lines(INPUT_FILE)
 
     # Parse the initial grid - infected nodes start at state 2

--- a/python/2017/23/solution1.py
+++ b/python/2017/23/solution1.py
@@ -19,9 +19,9 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/23/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
-from string import ascii_lowercase as letters
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
+from string import ascii_lowercase as letters  # noqa: E402
 
 
 class Coprocessor():
@@ -49,7 +49,7 @@ class Coprocessor():
             method(*instruction[1:],)
             if instruction[0] != 'jnz':
                 self.pointer += 1
-            if self.halted == True:
+            if self.halted:
                 return
         self.halted = True
         return

--- a/python/2017/23/solution2.py
+++ b/python/2017/23/solution2.py
@@ -16,10 +16,10 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/23/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
-from string import ascii_lowercase as letters
-from sympy import isprime
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
+from string import ascii_lowercase as letters  # noqa: E402
+from sympy import isprime  # noqa: E402
 
 
 class Coprocessor():
@@ -43,12 +43,13 @@ class Coprocessor():
         while -1 < self.pointer < len(self.program):
             instruction = self.program[self.pointer]
             # Uncomment for debugging:
-            # print(f"pc{self.id}:{self.pointer} - {instruction[0]} - {instruction[1]} ({self.get(instruction[1])}) - {instruction[2]} - ({self.get(instruction[2])})")
+            # print(f"pc{self.id}:{self.pointer} - {instruction[0]} - {instruction[1]} "
+            #       f"({self.get(instruction[1])}) - {instruction[2]} - ({self.get(instruction[2])})")
             method = getattr(self, instruction[0])
             method(*instruction[1:],)
             if instruction[0] != 'jnz':
                 self.pointer += 1
-            if self.halted == True:
+            if self.halted:
                 return
             # Uncomment for debugging:
             # print(f"register b, d, e: {self.registers['b']} {self.registers['d']} {self.registers['e']}")

--- a/python/2017/24/solution1.py
+++ b/python/2017/24/solution1.py
@@ -17,7 +17,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/24/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def build_strongest_bridge(available_components, current_strength, connector_port):

--- a/python/2017/24/solution2.py
+++ b/python/2017/24/solution2.py
@@ -14,7 +14,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/24/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
+from aoc_helpers import AoCInput, AoCUtils  # noqa: E402
 
 
 def build_longest_bridge(available_components, current_length, current_strength, connector_port):

--- a/python/2017/25/solution1.py
+++ b/python/2017/25/solution1.py
@@ -8,7 +8,7 @@ A Turing machine has:
 - A cursor that reads/writes values and moves left or right
 - Multiple states with rules defining behavior based on current tape values
 
-After running the machine for a specified number of steps (12,425,180 for this input),
+After running the machine for a specified number of steps (12, 425, 180 for this input),
 count how many 1s appear on the tape. This count is the diagnostic checksum.
 
 Note: The state machine logic is hardcoded based on the puzzle input blueprints.
@@ -19,8 +19,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_FILE = os.path.join(SCRIPT_DIR, '../../../../aoc-data/2017/25/input')
 sys.path.append(os.path.join(SCRIPT_DIR, '../../'))
 
-from aoc_helpers import AoCInput, AoCUtils
-from collections import defaultdict
+from aoc_helpers import AoCUtils  # noqa: E402
+from collections import defaultdict  # noqa: E402
 
 
 class TuringMachine():


### PR DESCRIPTION
- Add noqa: E402 comments to imports that follow sys.path manipulation
- Remove unused AoCInput imports (F401)
- Fix whitespace issues: E231 (missing space after comma), E203 (whitespace before colon)
- Fix E712 (comparison to True) by using direct boolean checks
- Fix E302/E305 by ensuring 2 blank lines between top-level functions
- Fix E501 (line too long) in 23/solution2.py by breaking long comment
- Fix W292 (no newline at end of file) and W293 (blank line whitespace)
- Refactor 19/solution1.py to reduce complexity (C901) by extracting helper functions

All 49 solution files now pass flake8 with max-line-length=119 and max-complexity=10.